### PR TITLE
Fix django 4.0

### DIFF
--- a/packages/jet_django/jet_django/router.py
+++ b/packages/jet_django/jet_django/router.py
@@ -1,5 +1,8 @@
 import sys
-from django.conf.urls import url
+try:
+    from django.conf.urls import url
+except ImportError:
+    from django.urls import path as url
 
 
 class Router(object):

--- a/packages/jet_django/jet_django/router.py
+++ b/packages/jet_django/jet_django/router.py
@@ -2,7 +2,7 @@ import sys
 try:
     from django.conf.urls import url
 except ImportError:
-    from django.urls import path as url
+    from django.urls import re_path as url
 
 
 class Router(object):

--- a/packages/jet_django/jet_django/urls.py
+++ b/packages/jet_django/jet_django/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls import url
+try:
+    from django.conf.urls import url
+except ImportError:
+    from django.urls import path as url
 
 from jet_bridge_base.views.api import ApiView
 from jet_bridge_base.views.external_auth.complete import ExternalAuthCompleteView

--- a/packages/jet_django/jet_django/urls.py
+++ b/packages/jet_django/jet_django/urls.py
@@ -1,7 +1,7 @@
 try:
     from django.conf.urls import url
 except ImportError:
-    from django.urls import path as url
+    from django.urls import re_path as url
 
 from jet_bridge_base.views.api import ApiView
 from jet_bridge_base.views.external_auth.complete import ExternalAuthCompleteView


### PR DESCRIPTION
As per Django 4.0 the use of django.conf.urls is deprecated. (https://docs.djangoproject.com/en/3.2/ref/urls/#url).

In order to support future django versions. This fix should be implemented.